### PR TITLE
Move acorn dep from node_modules to thirdparty lib folder. 

### DIFF
--- a/src/JSUtils/HintUtils.js
+++ b/src/JSUtils/HintUtils.js
@@ -26,7 +26,7 @@
 define(function (require, exports, module) {
 
 
-    var Acorn                       = require("node_modules/acorn/dist/acorn");
+    var Acorn                       = require("thirdparty/acorn/dist/acorn");
 
     var LANGUAGE_ID                 = "javascript",
         JSX_LANGUAGE_ID             = "jsx",

--- a/src/JSUtils/Session.js
+++ b/src/JSUtils/Session.js
@@ -32,8 +32,8 @@ define(function (require, exports, module) {
         HTMLUtils       = require("language/HTMLUtils"),
         HintUtils       = require("JSUtils/HintUtils"),
         ScopeManager    = require("JSUtils/ScopeManager"),
-        Acorn           = require("node_modules/acorn/dist/acorn"),
-        Acorn_Loose     = require("node_modules/acorn/dist/acorn_loose");
+        Acorn           = require("thirdparty/acorn/dist/acorn"),
+        Acorn_Loose     = require("thirdparty/acorn/dist/acorn_loose");
 
     /**
      * Session objects encapsulate state associated with a hinting session


### PR DESCRIPTION
https://github.com/aicore/phoenix/issues/11

* Changed acorn to be loaded from the third-party modules folder as Acorn is already available there.
* All unit tests passing as expected with no new failures noted.