### PR TITLE
Loading default project at startup 

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -257,23 +257,6 @@ define(function (require, exports, module) {
             );
         }
 
-        brackets.app.getRemoteDebuggingPort(function (err, remote_debugging_port){
-            var InfoBar = require('widgets/infobar'),
-                StringUtils = require("utils/StringUtils");
-            if ((!err) && remote_debugging_port && remote_debugging_port > 0) {
-                InfoBar.showInfoBar({
-                    type: "warning",
-                    title: `${Strings.REMOTE_DEBUGGING_ENABLED}${remote_debugging_port}`,
-                    description: ""
-                });
-            } else if (err) {
-                InfoBar.showInfoBar({
-                    type: "error",
-                    title: StringUtils.format(Strings.REMOTE_DEBUGGING_PORT_INVALID, err, 1024, 65534),
-                    description: ""
-                });
-            }
-        });
         // Use quiet scrollbars if we aren't on Lion. If we're on Lion, only
         // use native scroll bars when the mouse is not plugged in or when
         // using the "Always" scroll bar setting.

--- a/src/filesystem/impls/appshell/AppshellFileSystem.js
+++ b/src/filesystem/impls/appshell/AppshellFileSystem.js
@@ -148,6 +148,7 @@ define(function (require, exports, module) {
         }
 
         const FS_ERROR_CODES = window.Phoenix.app.ERR_CODES.FS_ERROR_CODES;
+        console.log('appshell fs error: ', err);
 
         switch (err.code) {
         case FS_ERROR_CODES.EINVAL:
@@ -331,7 +332,7 @@ define(function (require, exports, module) {
             callback = mode;
             mode = parseInt("0755", 8);
         }
-        appshell.fs.makedir(path, mode, function (err) {
+        appshell.fs.mkdir(path, mode, function (err) {
             if (err) {
                 callback(_mapError(err));
             } else {
@@ -541,22 +542,21 @@ define(function (require, exports, module) {
      */
     function watchPath(path, ignored, callback) {
         console.log('Watch path: ', path);
-        if (_isRunningOnWindowsXP) {
-            callback(FileSystemError.NOT_SUPPORTED);
-            return;
-        }
-        appshell.fs.isNetworkDrive(path, function (err, isNetworkDrive) {
-            if (err || isNetworkDrive) {
-                if (isNetworkDrive) {
-                    callback(FileSystemError.NETWORK_DRIVE_NOT_SUPPORTED);
-                } else {
-                    callback(FileSystemError.UNKNOWN);
-                }
-                return;
-            }
-            _nodeDomain.exec("watchPath", path, ignored)
-                .then(callback, callback);
-        });
+        callback(FileSystemError.NOT_SUPPORTED);
+        return;
+        // TODO: Phoenix. file watch fix.
+        // appshell.fs.watch(path, function (err, isNetworkDrive) {
+        //     if (err || isNetworkDrive) {
+        //         if (isNetworkDrive) {
+        //             callback(FileSystemError.NETWORK_DRIVE_NOT_SUPPORTED);
+        //         } else {
+        //             callback(FileSystemError.UNKNOWN);
+        //         }
+        //         return;
+        //     }
+        //     _nodeDomain.exec("watchPath", path, ignored)
+        //         .then(callback, callback);
+        // });
     }
     /**
      * Stop providing change notifications for the file or directory at the

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -700,7 +700,7 @@ define(function (require, exports, module) {
      * @return {!string} fullPath reference
      */
     function _getWelcomeProjectPath() {
-        return ProjectModel._getWelcomeProjectPath(Urls.GETTING_STARTED, FileUtils.getNativeBracketsDirectoryPath());
+        return ProjectModel._getWelcomeProjectPath(Urls.GETTING_STARTED, Phoenix.VFS.getDefaultProjectDir());
     }
 
     /**


### PR DESCRIPTION
* Loading default project from VFS at startup 
* Disabling unsupported file watcher for now. tracked in https://github.com/aicore/phoenix/issues/47
* Remove brackets remote debugging as its not required in the browser.

https://github.com/aicore/phoenix/issues/22