### PR TITLE
Prevent sending page title to google analytics for privacy.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,9 @@
         gtag('js', new Date());
 
         gtag('config', 'G-P4HJFPDB76');
+        gtag('config', 'G-P4HJFPDB76', {
+            send_page_title: false
+        });
     </script>
 
     <!-- Import the phoenix browser virtual file system -->


### PR DESCRIPTION
* We will only be sending page view count to analytics.