### PR TITLE
Fix chrome slow scroll with scroll wheel bug

### DIFF
--- a/src/extensions/default/DarkTheme/main.less
+++ b/src/extensions/default/DarkTheme/main.less
@@ -41,11 +41,6 @@
 
 /* Code Styling */
 
-.CodeMirror, .CodeMirror-scroll {
-    background-color: @background;
-    color: @foreground;
-}
-
 .CodeMirror-focused .CodeMirror-activeline-background {
     background: #2f2f2f;
 }
@@ -129,6 +124,9 @@
     other than a vanilla .CodeMirror)
  */
 .CodeMirror {
+    background-color: @background;
+    color: @foreground;
+
     .CodeMirror {
         background: transparent;
     }

--- a/src/styles/brackets_codemirror_override.less
+++ b/src/styles/brackets_codemirror_override.less
@@ -35,10 +35,6 @@
     padding-left: 0;
 }
 
-.CodeMirror-scroll {
-    background-color: @background;
-}
-
 .CodeMirror {
     .code-font();
 }


### PR DESCRIPTION
* In google chrome, when we scroll any multi-page code file with the mouse scroll wheel, the scroll is very slow. This change fixes the issue.
* Problem not noted in Firefox.

## Testing
* Tested working in chrome and firefox with the dark and light theme.
* On the first launch no themes are loaded, This is a brackets theme loading issue and not related tho this change. Reload phoenix to load themes.