### PR TITLE
Copy file API for fs native

### DIFF
--- a/src/phoenix/fslib.js
+++ b/src/phoenix/fslib.js
@@ -123,6 +123,12 @@ const fileSystemLib = {
         }
         return filerShell.rm(path, { recursive: true }, cb);
     },
+    copyFile: function (src, dst, callback) {
+        if(Mounts.isMountSubPath(src) && Mounts.isMountSubPath(dst)) {
+            return NativeFS.copyFile(src, dst, callback);
+        }
+        throw new Errors.ENOSYS('Phoenix fs copy on filer or across filer and native not yet supported');
+    },
     showSaveDialog: function () {
         throw new Errors.ENOSYS('Phoenix fs showSaveDialog function not yet supported.');
     },

--- a/src/phoenix/fslib_mounts.js
+++ b/src/phoenix/fslib_mounts.js
@@ -271,6 +271,18 @@ function getHandleFromPath(normalisedPath, callback) {
     });
 }
 
+async function getHandleFromPathIfPresent(normalisedPath) {
+    return new Promise(resolve => {
+        getHandleFromPath(normalisedPath, (err, handle) =>{
+            if(err) {
+                resolve(null);
+            } else {
+                resolve(handle);
+            }
+        });
+    });
+}
+
 function getMountPoints() {
     return MountPointsStore.getMountPoints();
 }
@@ -287,7 +299,8 @@ const Mounts = {
     isMountSubPath,
     getHandleFromPath,
     getMountPoints,
-    refreshMountPoints
+    refreshMountPoints,
+    getHandleFromPathIfPresent
 };
 
 export default Mounts;

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -36,8 +36,11 @@
   </script>
 
   <!-- Import the phoenix browser virtual file system -->
+  <script src="../src/thirdparty/idb/idb-min.js"></script>
   <script src="../src/thirdparty/filer/filer.min.js"></script>
+  <script src="../src/thirdparty/Buffer/buffer-min.js"></script>
   <script src="../src/phoenix/shell.js" type="module"></script>
+  <script src="../src/phoenix/nohost_server.js" type="module"></script>
 
   <script src="thirdparty/jasmine-core/jasmine.js"></script>
   <!-- Pre-load third party scripts that cannot be async loaded. -->


### PR DESCRIPTION
As fs access APIs do not support copy/rename functions, we have to implement these functions manually. This PR implements file copy within mount points.

This copy impl follows the semantics of Linux cp command: https://www.geeksforgeeks.org/cp-command-linux-examples/

## know issues
* copy is currently not supported between filer and mount points.
* not supported within filer, we can use filer.rename when needed for rename, copy is to be implemented.

https://github.com/aicore/phoenix/issues/3