### PR TITLE
Add GNU AGPL license header for files in phoenix folder

### DIFF
--- a/src/phoenix/constants.js
+++ b/src/phoenix/constants.js
@@ -1,26 +1,21 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
-
+  
 // jshint ignore: start
 /*global fs, Phoenix, process*/
 /*eslint no-console: 0*/

--- a/src/phoenix/constants.js
+++ b/src/phoenix/constants.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License as published by the Free

--- a/src/phoenix/constants.js
+++ b/src/phoenix/constants.js
@@ -1,10 +1,10 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
@@ -15,7 +15,7 @@
  * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
-  
+
 // jshint ignore: start
 /*global fs, Phoenix, process*/
 /*eslint no-console: 0*/

--- a/src/phoenix/errno.js
+++ b/src/phoenix/errno.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  * Copyright (c) 2012-2015 Rod Vagg (@rvagg)
  * Based on : https://github.com/rvagg/node-errno
  *

--- a/src/phoenix/errno.js
+++ b/src/phoenix/errno.js
@@ -1,12 +1,12 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  * Copyright (c) 2012-2015 Rod Vagg (@rvagg)
  * Based on : https://github.com/rvagg/node-errno
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;

--- a/src/phoenix/errno.js
+++ b/src/phoenix/errno.js
@@ -1,25 +1,20 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  * Copyright (c) 2012-2015 Rod Vagg (@rvagg)
  * Based on : https://github.com/rvagg/node-errno
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/fslib.js
+++ b/src/phoenix/fslib.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License as published by the Free

--- a/src/phoenix/fslib.js
+++ b/src/phoenix/fslib.js
@@ -1,23 +1,18 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/fslib.js
+++ b/src/phoenix/fslib.js
@@ -1,10 +1,10 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;

--- a/src/phoenix/fslib_mounts.js
+++ b/src/phoenix/fslib_mounts.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License as published by the Free

--- a/src/phoenix/fslib_mounts.js
+++ b/src/phoenix/fslib_mounts.js
@@ -1,23 +1,18 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/fslib_mounts.js
+++ b/src/phoenix/fslib_mounts.js
@@ -1,10 +1,10 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;

--- a/src/phoenix/fslib_native.js
+++ b/src/phoenix/fslib_native.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License as published by the Free

--- a/src/phoenix/fslib_native.js
+++ b/src/phoenix/fslib_native.js
@@ -1,23 +1,18 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/fslib_native.js
+++ b/src/phoenix/fslib_native.js
@@ -1,10 +1,10 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;

--- a/src/phoenix/fslib_watch.js
+++ b/src/phoenix/fslib_watch.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License as published by the Free

--- a/src/phoenix/fslib_watch.js
+++ b/src/phoenix/fslib_watch.js
@@ -1,23 +1,18 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/fslib_watch.js
+++ b/src/phoenix/fslib_watch.js
@@ -1,10 +1,10 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;

--- a/src/phoenix/init_vfs.js
+++ b/src/phoenix/init_vfs.js
@@ -1,24 +1,19 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  * Acknowledgements: https://github.com/bpedro/node-fs
+ * 
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/init_vfs.js
+++ b/src/phoenix/init_vfs.js
@@ -1,11 +1,11 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  * Acknowledgements: https://github.com/bpedro/node-fs
- * 
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;

--- a/src/phoenix/init_vfs.js
+++ b/src/phoenix/init_vfs.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  * Acknowledgements: https://github.com/bpedro/node-fs
  *
  * This program is free software: you can redistribute it and/or modify it under

--- a/src/phoenix/mount_point_storage.js
+++ b/src/phoenix/mount_point_storage.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License as published by the Free

--- a/src/phoenix/mount_point_storage.js
+++ b/src/phoenix/mount_point_storage.js
@@ -1,23 +1,18 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/mount_point_storage.js
+++ b/src/phoenix/mount_point_storage.js
@@ -1,10 +1,10 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;

--- a/src/phoenix/nohost_server.js
+++ b/src/phoenix/nohost_server.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License as published by the Free

--- a/src/phoenix/nohost_server.js
+++ b/src/phoenix/nohost_server.js
@@ -1,23 +1,18 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/nohost_server.js
+++ b/src/phoenix/nohost_server.js
@@ -1,10 +1,10 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License as published by the Free

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -1,23 +1,18 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/shell.js
+++ b/src/phoenix/shell.js
@@ -1,10 +1,10 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;

--- a/src/phoenix/utils.js
+++ b/src/phoenix/utils.js
@@ -1,7 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified work Copyright (c) 2021 - present Core.ai
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU Affero General Public License as published by the Free

--- a/src/phoenix/utils.js
+++ b/src/phoenix/utils.js
@@ -1,23 +1,18 @@
 /*
- * Copyright (c) 2021 - present core.ai . All rights reserved.
+ * GNU AGPL-3.0 License
+ * 
+ * Modified work Copyright (c) 2021 - present Core.ai
  *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
+ * This program is free software: you can redistribute it and/or modify it under 
+ * the terms of the GNU Affero General Public License as published by the Free 
+ * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
  *
  */
 

--- a/src/phoenix/utils.js
+++ b/src/phoenix/utils.js
@@ -1,10 +1,10 @@
 /*
  * GNU AGPL-3.0 License
- * 
+ *
  * Modified work Copyright (c) 2021 - present Core.ai
  *
- * This program is free software: you can redistribute it and/or modify it under 
- * the terms of the GNU Affero General Public License as published by the Free 
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
  * Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;


### PR DESCRIPTION
All files in the phoenix folder are added with the following GNU AGPL license header
#186 
```
  GNU AGPL-3.0 License
  
  Modified work Copyright (c) 2021 - present Core.ai
  
  This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  
  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
  
  You should have received a copy of the GNU Affero General Public License along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
```