### PR TITLE
Testing framework enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Phoenix is in alpha and is under active development.
 * To build the release artifacts: `npm run release`
 * The release artifacts to host will be in `dist` folder.
 
+## Running tests
+* run `npm run test` in the terminal.
+  * NB: this will setup all the required files for test 
+* Use chrome/edge browser to navigate to Phoenix[http://localhost:8000/src/index.html](http://localhost:8000/src/index.html)
+* In Phoenix Menu, select `Debug > run Tests` To open the test runner.
+* Run tests as required. 
+  * NB: To reset test data files, click on `reset and reload tests` option in the test runner.  
+
 ## Acknowledgements
 * Phoenix is based on the Brackets code editor by Adobe. Find out more on [Adobe Brackets here](https://github.com/adobe/brackets/).
 * Inspired by previous work from the [Mozilla Thimble](https://github.com/mozilla/thimble.mozilla.org) project to port brackets to the web. https://github.com/mozilla/brackets

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -85,7 +85,8 @@ function serveExternal() {
 function zipTestFiles() {
     return src([
         'test/**',
-        '!test/thirdparty/**'])
+        '!test/thirdparty/**',
+        '!test/test_folders.zip'])
         .pipe(zip('test_folders.zip'))
         .pipe(dest('test/'));
 }

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -73,12 +73,15 @@
               <li><a id="mainview"    href="?suite=mainview">Main&nbsp;View</a></li>
               <li><a id="performance" href="?suite=performance">Performance</a></li>
               <li><a id="extension" href="?suite=extension">Extensions</a></li>
-              <li><a id="reload" href="#">Reload</a></li>
+              <li><a id="reload" href="#">Reset and Reload Tests</a></li>
               <li><a id="show-dev-tools" href="#">Show&nbsp;Developer&nbsp;Tools</a></li>
             </ul>
           </div>
         </div>
       </div>
+    </div>
+    <div id="loading" style="display: none;">
+      Extracting test files .... <img src="../src/styles/images/throbber.gif" alt=".......">
     </div>
     <div id="mock-main-view" style="position:absolute; height:1000px; width:1000px; left:-10000px; top:-10000px;"></div>
     <!-- All other scripts are loaded through require. -->


### PR DESCRIPTION
- Extract unit test files to phoenix fs on start. 
- Adding reset and reload tests option 
- docs: docs update for running tests 


* 230 unit tests failing after fix reduced from 350. https://github.com/aicore/phoenix/issues/91
