### PR TITLE
fix: limit page details from being logged in page view to improve privacy

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
   DEALINGS IN THE SOFTWARE.
 -->
 
-<html spellcheck="false">
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name= "viewport" content="width=device-width, user-scalable=no" />
@@ -39,9 +39,10 @@
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'G-P4HJFPDB76');
         gtag('config', 'G-P4HJFPDB76', {
-            send_page_title: false
+            'page_title' : 'Phoenix editor',
+            'page_path': '/index.html',
+            'page_location': window.location.origin
         });
     </script>
 


### PR DESCRIPTION
*  limit page details from being logged in google analytics 
* Earlier page title used to be sent with page_vide event when ga inits. Page title contained project file path that needs to be not logged. Overriding those titles to contacts to prevent logging user private information.