### PR TITLE
fix: defer loading of gtag manager till brackets config with Google Analytics id is loaded

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -32,8 +32,6 @@
     <!-- CSS/LESS -->
 
     <!-- NOTE: All scripts must be external for Chrome App support: http://developer.chrome.com/apps/app_csp.html -->
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P4HJFPDB76"></script>
 
     <link rel="stylesheet" type="text/css" href="thirdparty/CodeMirror/lib/codemirror.css">
     <link rel="stylesheet/less" type="text/css" href="styles/brackets.less">


### PR DESCRIPTION
* Problem was all deployments default to dev ga id hardcoded in index.html file.
* Changes impl to load ga scripts at runtime after load.
* Tested ga dev endpoints hitting as expected.