### PR TITLE
Adding require alias for view/panelManager older extension compatibility

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,8 @@ require.config({
     map: {
         "*": {
             "thirdparty/CodeMirror2": "thirdparty/CodeMirror",
-            "thirdparty/preact": "preact-compat"
+            "thirdparty/preact": "preact-compat",
+            "view/PanelManager": "view/WorkspaceManager"  // For extension compatibility
         }
     }
 });


### PR DESCRIPTION
Brackets change: https://github.com/brackets-cont/brackets/pull/85

* Removed in assuming that no extensions were using it https://github.com/adobe/brackets/pull/11589
* Caused extension break https://github.com/jadbox/brackets-integrated-development
* and general extension issues later https://github.com/adobe/brackets/issues/11960

We just create an alias here as the Panel manager. Workspace manager is a superset of panel manager APIs

## Testing
* Brackets IDE extension now works with python
* Extension load that used old panel APIs working