### PR TITLE
Move remote file adapter to core from extension

### DIFF
--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -28,8 +28,6 @@ define(function (require, exports, module) {
         EditorManager,          // loaded from brackets.test
         PerfUtils,              // loaded from brackets.test
         JSUtils,                // loaded from brackets.test
-
-        FileUtils           = brackets.getModule("file/FileUtils"),
         SpecRunnerUtils     = brackets.getModule("spec/SpecRunnerUtils"),
         Strings             = brackets.getModule("strings"),
         UnitTestReporter    = brackets.getModule("test/UnitTestReporter");

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -23,7 +23,6 @@ define(function (require, exports, module) {
 
 
     var AppInit         = brackets.getModule("utils/AppInit"),
-        FileSystem      = brackets.getModule("filesystem/FileSystem"),
         QuickOpen       = brackets.getModule("search/QuickOpen"),
         PathUtils       = brackets.getModule("thirdparty/path-utils/path-utils"),
         CommandManager  = brackets.getModule("command/CommandManager"),
@@ -31,8 +30,7 @@ define(function (require, exports, module) {
         ExtensionUtils = brackets.getModule("utils/ExtensionUtils"),
         WorkingSetView = brackets.getModule("project/WorkingSetView"),
         MainViewManager = brackets.getModule("view/MainViewManager"),
-        Menus           = brackets.getModule("command/Menus"),
-        RemoteFile      = require("RemoteFile");
+        Menus           = brackets.getModule("command/Menus");
 
     var HTTP_PROTOCOL = "http:",
         HTTPS_PROTOCOL = "https:";
@@ -71,18 +69,6 @@ define(function (require, exports, module) {
         Menus.getContextMenu(Menus.ContextMenuIds.WORKING_SET_CONTEXT_MENU).on("beforeContextMenuOpen", _setMenuItemsVisible);
         MainViewManager.on("currentFileChange", _setMenuItemsVisible);
 
-        var protocolAdapter = {
-            priority: 0, // Default priority
-            fileImpl: RemoteFile,
-            canRead: function (filePath) {
-                return true; // Always claim true, we are the default adpaters
-            }
-        };
-
-        // Register the custom object as HTTP and HTTPS protocol adapter
-        FileSystem.registerProtocolAdapter(HTTP_PROTOCOL, protocolAdapter);
-        FileSystem.registerProtocolAdapter(HTTPS_PROTOCOL, protocolAdapter);
-
         // Register as quick open plugin for file URI's having HTTP:|HTTPS: protocol
         QuickOpen.addQuickOpenPlugin(
             {
@@ -96,7 +82,8 @@ define(function (require, exports, module) {
                     return [HTTP_PROTOCOL, HTTPS_PROTOCOL].indexOf(protocol) !== -1;
                 },
                 itemFocus: function (query) {
-                }, // no op
+                    // no op
+                },
                 itemSelect: function () {
                     CommandManager.execute(Commands.FILE_OPEN, {fullPath: arguments[0]});
                 }

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -91,6 +91,7 @@ define(function (require, exports, module) {
         File            = require("filesystem/File"),
         FileIndex       = require("filesystem/FileIndex"),
         FileSystemError = require("filesystem/FileSystemError"),
+        RemoteFile      = require("filesystem/RemoteFile"),
         WatchedRoot     = require("filesystem/WatchedRoot"),
         EventDispatcher = require("utils/EventDispatcher"),
         PathUtils       = require("thirdparty/path-utils/path-utils"),
@@ -1099,4 +1100,20 @@ define(function (require, exports, module) {
 
     // Initialize the singleton instance
     _instance.init(require("fileSystemImpl"));
+
+    // attach remote file handlers
+    var HTTP_PROTOCOL = "http:",
+        HTTPS_PROTOCOL = "https:";
+
+    var protocolAdapter = {
+        priority: 0, // Default priority
+        fileImpl: RemoteFile,
+        canRead: function (filePath) {
+            return true; // Always claim true, we are the default adpaters
+        }
+    };
+
+    // Register the custom object as HTTP and HTTPS protocol adapter
+    registerProtocolAdapter(HTTP_PROTOCOL, protocolAdapter);
+    registerProtocolAdapter(HTTPS_PROTOCOL, protocolAdapter);
 });


### PR DESCRIPTION
* Move remote file adapter to core Reading HTTP/HTTPS remote content as a file is a core requirement. 
* Fixes MDN Docs(except 1) and remote file extension Tests
* Added support for file reads on any browser supported encoding from HTTP/HTTPS links

- fix: remove unused import

## Testing
* All but 1 MDN Docs extension tests working
* All remote file extension tests working.
* Varified `ctrl_shift+o` to open an http/s URL works.
* 1 more unit test passing from general tests.