### PR TITLE
Debug commands to browse virtual fs and server

### DIFF
--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -42,6 +42,7 @@ define(function (require, exports, module) {
         ExtensionManager       = brackets.getModule("extensibility/ExtensionManager"),
         Mustache               = brackets.getModule("thirdparty/mustache/mustache"),
         Locales                = brackets.getModule("nls/strings"),
+        ProjectManager         = brackets.getModule("project/ProjectManager"),
         PerfDialogTemplate     = require("text!htmlContent/perf-dialog.html"),
         LanguageDialogTemplate = require("text!htmlContent/language-dialog.html");
 
@@ -71,6 +72,8 @@ define(function (require, exports, module) {
         DEBUG_NEW_BRACKETS_WINDOW             = "debug.newBracketsWindow",
         DEBUG_SWITCH_LANGUAGE                 = "debug.switchLanguage",
         DEBUG_ENABLE_LOGGING                  = "debug.enableLogging",
+        DEBUG_OPEN_VFS                        = "debug.openVFS",
+        DEBUG_OPEN_VIRTUAL_SERVER             = "debug.openVirtualServer",
         DEBUG_OPEN_PREFERENCES_IN_SPLIT_VIEW  = "debug.openPrefsInSplitView";
 
     // define a preference to turn off opening preferences in split-view.
@@ -701,6 +704,14 @@ define(function (require, exports, module) {
         recomputeDefaultPrefs = true;
     });
 
+    function _openVFS() {
+        ProjectManager.openProject("/");
+    }
+
+    function _openVirtualServer() {
+        window.open(window.fsServerUrl);
+    }
+
     /* Register all the command handlers */
     CommandManager.register(Strings.CMD_REFRESH_WINDOW,             DEBUG_REFRESH_WINDOW,           handleReload);
     CommandManager.register(Strings.CMD_RELOAD_WITHOUT_USER_EXTS,   DEBUG_RELOAD_WITHOUT_USER_EXTS, handleReloadWithoutUserExts);
@@ -713,8 +724,9 @@ define(function (require, exports, module) {
 
     CommandManager.register(Strings.CMD_SWITCH_LANGUAGE,           DEBUG_SWITCH_LANGUAGE,           handleSwitchLanguage);
 
-    // Node-related Commands
     CommandManager.register(Strings.CMD_ENABLE_LOGGING, DEBUG_ENABLE_LOGGING,   _handleLogging);
+    CommandManager.register(Strings.CMD_OPEN_VFS, DEBUG_OPEN_VFS,   _openVFS);
+    CommandManager.register(Strings.CMD_OPEN_VIRTUAL_SERVER, DEBUG_OPEN_VIRTUAL_SERVER,   _openVirtualServer);
 
     CommandManager.register(Strings.CMD_OPEN_PREFERENCES, DEBUG_OPEN_PREFERENCES_IN_SPLIT_VIEW, handleOpenPrefsInSplitView);
     /*
@@ -731,6 +743,9 @@ define(function (require, exports, module) {
     menu.addMenuItem(DEBUG_SHOW_PERF_DATA);
     menu.addMenuDivider();
     menu.addMenuItem(DEBUG_ENABLE_LOGGING);
+    menu.addMenuItem(DEBUG_OPEN_VFS);
+    menu.addMenuItem(DEBUG_OPEN_VIRTUAL_SERVER);
+    menu.addMenuDivider();
     menu.addMenuItem(DEBUG_OPEN_PREFERENCES_IN_SPLIT_VIEW); // this command will enable defaultPreferences and brackets preferences to be open side by side in split view.
     menu.addMenuItem(Commands.FILE_OPEN_KEYMAP);      // this command is defined in core, but exposed only in Debug menu for now
 

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -436,6 +436,10 @@ define({
     "CMD_SHOW_IN_OS": "Show in OS",
     "CMD_SWITCH_PANE_FOCUS": "Switch Pane Focus",
 
+    // Debug menu commands
+    "CMD_OPEN_VFS": "Open Virtual File System",
+    "CMD_OPEN_VIRTUAL_SERVER": "Open Virtual Server",
+
     // Help menu commands
     "HELP_MENU": "Help",
     "CMD_CHECK_FOR_UPDATE": "Check for Updates",


### PR DESCRIPTION
Added Debug Menu items
* Open Virtual File System: opens `/` folder as current project
* Open virtual server: Opens vfs url to prowse in new tab
![image](https://user-images.githubusercontent.com/5336369/147868994-131dd9f1-aa1a-453f-b04e-e97b5dde3c55.png)
