### PR TITLE
unified working set menu

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -236,13 +236,6 @@ define(function (require, exports, module) {
         workingset_cmenu.addMenuDivider();
         workingset_cmenu.addMenuItem(Commands.FILE_CLOSE);
 
-        var workingset_configuration_menu = Menus.registerContextMenu(Menus.ContextMenuIds.WORKING_SET_CONFIG_MENU);
-        workingset_configuration_menu.addMenuItem(Commands.CMD_WORKINGSET_SORT_BY_ADDED);
-        workingset_configuration_menu.addMenuItem(Commands.CMD_WORKINGSET_SORT_BY_NAME);
-        workingset_configuration_menu.addMenuItem(Commands.CMD_WORKINGSET_SORT_BY_TYPE);
-        workingset_configuration_menu.addMenuDivider();
-        workingset_configuration_menu.addMenuItem(Commands.CMD_WORKING_SORT_TOGGLE_AUTO);
-
         var splitview_menu = Menus.registerContextMenu(Menus.ContextMenuIds.SPLITVIEW_MENU);
         splitview_menu.addMenuItem(Commands.CMD_SPLITVIEW_NONE);
         splitview_menu.addMenuItem(Commands.CMD_SPLITVIEW_VERTICAL);
@@ -330,9 +323,6 @@ define(function (require, exports, module) {
         $("#project-files-container").on("contextmenu", function (e) {
             project_cmenu.open(e);
         });
-
-        // Dropdown menu for workspace sorting
-        Menus.ContextMenu.assignContextMenuToSelector(".working-set-option-btn", workingset_configuration_menu);
 
         // Dropdown menu for view splitting
         Menus.ContextMenu.assignContextMenuToSelector(".working-set-splitview-btn", splitview_menu);

--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -247,6 +247,12 @@ define(function (require, exports, module) {
         splitview_menu.addMenuItem(Commands.CMD_SPLITVIEW_NONE);
         splitview_menu.addMenuItem(Commands.CMD_SPLITVIEW_VERTICAL);
         splitview_menu.addMenuItem(Commands.CMD_SPLITVIEW_HORIZONTAL);
+        splitview_menu.addMenuDivider();
+        splitview_menu.addMenuItem(Commands.CMD_WORKINGSET_SORT_BY_ADDED);
+        splitview_menu.addMenuItem(Commands.CMD_WORKINGSET_SORT_BY_NAME);
+        splitview_menu.addMenuItem(Commands.CMD_WORKINGSET_SORT_BY_TYPE);
+        splitview_menu.addMenuDivider();
+        splitview_menu.addMenuItem(Commands.CMD_WORKING_SORT_TOGGLE_AUTO);
 
         var project_cmenu = Menus.registerContextMenu(Menus.ContextMenuIds.PROJECT_MENU);
         project_cmenu.addMenuItem(Commands.FILE_NEW);

--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -42,7 +42,6 @@
     <div class="main-view">
         <div id="sidebar" class="sidebar panel quiet-scrollbars horz-resizable right-resizer collapsible" data-minsize="0" data-maxsize="80%" data-forceleft=".content">
             <div class="working-set-splitview-btn btn-alt-quiet"></div>
-            <div class="working-set-option-btn btn-alt-quiet"></div>
 
             <div id="working-set-list-container">
 

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -127,7 +127,6 @@ define(function (require, exports, module) {
      */
     function _updateUIStates() {
         var spriteIndex,
-            ICON_CLASSES = ["splitview-icon-none", "splitview-icon-vertical", "splitview-icon-horizontal"],
             layoutScheme = MainViewManager.getLayoutScheme();
 
         if (layoutScheme.columns > 1) {
@@ -137,10 +136,6 @@ define(function (require, exports, module) {
         } else {
             spriteIndex = 0;
         }
-
-        // SplitView Icon
-        $splitViewMenu.removeClass(ICON_CLASSES.join(" "))
-                      .addClass(ICON_CLASSES[spriteIndex]);
 
         // SplitView Menu
         _cmdSplitNone.setChecked(spriteIndex === 0);

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -47,7 +47,6 @@ define(function (require, exports, module) {
     // These vars are initialized by the htmlReady handler
     // below since they refer to DOM elements
     var $sidebar,
-        $gearMenu,
         $splitViewMenu,
         $projectTitle,
         $projectFilesContainer,
@@ -178,7 +177,6 @@ define(function (require, exports, module) {
     // Initialize items dependent on HTML DOM
     AppInit.htmlReady(function () {
         $sidebar                  = $("#sidebar");
-        $gearMenu                 = $sidebar.find(".working-set-option-btn");
         $splitViewMenu            = $sidebar.find(".working-set-splitview-btn");
         $projectTitle             = $sidebar.find("#project-title");
         $projectFilesContainer    = $sidebar.find("#project-files-container");
@@ -241,7 +239,6 @@ define(function (require, exports, module) {
         _updateUIStates();
 
         // Tooltips
-        $gearMenu.attr("title", Strings.GEAR_MENU_TOOLTIP);
         $splitViewMenu.attr("title", Strings.GEAR_MENU_TOOLTIP);
     });
 

--- a/src/project/SidebarView.js
+++ b/src/project/SidebarView.js
@@ -111,14 +111,19 @@ define(function (require, exports, module) {
      * @private
      */
     function _updateWorkingSetState() {
+        let enabled = false;
+
         if (MainViewManager.getPaneCount() === 1 &&
                 MainViewManager.getWorkingSetSize(MainViewManager.ACTIVE_PANE) === 0) {
             $workingSetViewsContainer.hide();
-            $gearMenu.hide();
         } else {
             $workingSetViewsContainer.show();
-            $gearMenu.show();
+            enabled = true;
         }
+        CommandManager.get(Commands.CMD_WORKINGSET_SORT_BY_ADDED).setEnabled(enabled);
+        CommandManager.get(Commands.CMD_WORKINGSET_SORT_BY_NAME).setEnabled(enabled);
+        CommandManager.get(Commands.CMD_WORKINGSET_SORT_BY_TYPE).setEnabled(enabled);
+        CommandManager.get(Commands.CMD_WORKING_SORT_TOGGLE_AUTO).setEnabled(enabled);
     }
 
     /**
@@ -237,7 +242,7 @@ define(function (require, exports, module) {
 
         // Tooltips
         $gearMenu.attr("title", Strings.GEAR_MENU_TOOLTIP);
-        $splitViewMenu.attr("title", Strings.SPLITVIEW_MENU_TOOLTIP);
+        $splitViewMenu.attr("title", Strings.GEAR_MENU_TOOLTIP);
     });
 
     ProjectManager.on("projectOpen", _updateProjectTitle);

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -845,12 +845,15 @@ a, img {
 }
 
 .splitview-icon-none {
+    display: inline-block;
     background-position: center 1px;
 }
 .splitview-icon-vertical {
+    display: inline-block;
     background-position: center -20px;
 }
 .splitview-icon-horizontal {
+    display: inline-block;
     background-position: center -41px;
 }
 
@@ -859,7 +862,7 @@ a, img {
 // Show splitview icons on the button's dropdown menu too
 #splitview-menu ul.dropdown-menu > li {
     .menu-name::before {
-        display: inline-block;
+        display: none;
         .sprite-icon(0, 0, 13px, 13px, "images/split-view-icons.svg");
         margin: 0 5px 0 -1px;
         vertical-align: -2px;

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -834,13 +834,14 @@ a, img {
     right: 4px;
     top: 7px;
     padding: 4px 6px;
-    .sprite-icon(0, 0, 13px, 13px, "images/split-view-icons.svg");
+    .sprite-icon(0, 0, 13px, 13px, "images/select-triangles.svg");
     background-origin: content-box;  // center image within the 13x13 area - ignore button's padding
     -webkit-transform: translateZ(0); // forces GPU mode for better filter rendering on retina
     transform: translateZ(0); // future proofing
     -webkit-filter: drop-shadow(0 1px 0 rgba(0,0,0,0.36));
     filter: drop-shadow(0 1px 0 rgba(0,0,0,0.36));
     z-index: 1;
+    background-position: center 1px;
 }
 
 .splitview-icon-none {

--- a/src/styles/brackets.less
+++ b/src/styles/brackets.less
@@ -818,17 +818,6 @@ a, img {
     }
 }
 
-.working-set-option-btn {
-    position: absolute;
-    right: 30px;
-    top: 7px;
-    padding: 4px 6px;
-    .sprite-icon(0, 0, 13px, 13px, "images/topcoat-settings-13.svg");
-    background-position: center;
-    opacity: 0.8;
-    z-index: 1;
-}
-
 .working-set-splitview-btn {
     position: absolute;
     right: 4px;


### PR DESCRIPTION
## Improve screen real estate utilization and prepare for front and back navigation icons
Earlier we had two separate icons like shown in this image 
![image](https://user-images.githubusercontent.com/5336369/147878668-3082b38e-1f3e-4c6a-809d-11b3a6356179.png)

Now we merged the gear icon(doing workspace file sort) and workspace split-view icon into a single unified workspace icon.
- feat: changed working set split-view icon
- feat: add working set sort options to a unified working set menu
- feat: unified working set menu and removed old gear menu

## New Workflow images
![image](https://user-images.githubusercontent.com/5336369/147878594-4cfc5811-25ad-41b1-adcb-d432dcff0733.png)

### Sort options disabled if there are no working set files to sort
![image](https://user-images.githubusercontent.com/5336369/147878600-4c3326f7-bb77-43ef-8989-0c8785508244.png)

## Testing
Unit and workspace integration tests pass with no changes.