### PR TITLE
feat: made plugin panel re-sizable and re-layout UI on resize

### DIFF
--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -86,14 +86,15 @@
         <!-- Vertical toolbar docked to right -->
         <div id="main-toolbar" class="toolbar no-focus collapsible">
             <!-- Top-aligned buttons -->
+            <div id="plugin-panel">
+            </div>
             <div class="buttons">
                 <a id="toolbar-go-live" href="#"></a> <!-- tooltip for this is set in JS -->
                 <a id="toolbar-extension-manager" title="{{Strings.EXTENSION_MANAGER_TITLE}}" href="#"></a>
                 <a id="update-notification" title="{{Strings.UPDATE_NOTIFICATION_TOOLTIP}}" href="#" style="display: none"></a>
             </div>
             <div class="bottom-buttons"></div>
-            <div id="plugin-panel">
-            </div>
+
         </div>
 
         <!-- Hack to ensure that the code editor's web font is loaded early. -->

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -175,7 +175,7 @@ a:focus {
 #main-toolbar {
     position: absolute;
     display: flex !important;
-    flex-direction: row-reverse;
+    flex-direction: row;
     justify-content: space-between;
     top: 0;
     right: 0;

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -188,12 +188,17 @@ define(function (require, exports, module) {
      * @param {?boolean} createdByWorkspaceManager For internal use only
      * @param {?boolean} usePercentages Maintain the size of the element as a percentage of its parent
      *                          the default is to maintain the size of the element in pixels
+     * @param {?string} forceRight CSS selector indicating element whose 'right' should be locked to the
+     *                          the resizable element's size (useful for siblings laid out to the left of
+     *                          the element). Must lie in element's parent's subtree.
      * @param {?boolean} _attachToParent Attaches the resizer element to parent of the element rather than
      *                          to element itself. Attach the resizer to the parent *ONLY* if element has the
      *                          same offset as parent otherwise the resizer will be incorrectly positioned.
      *                          FOR INTERNAL USE ONLY
      */
-    function makeResizable(element, direction, position, minSize, collapsible, forceLeft, createdByWorkspaceManager, usePercentages, _attachToParent) {
+    function makeResizable(element, direction, position, minSize, collapsible,
+                           forceLeft, createdByWorkspaceManager, usePercentages,
+                           forceRight, _attachToParent) {
         var $resizer            = $('<div class="' + direction + '-resizer"></div>'),
             $element            = $(element),
             $parent             = $element.parent(),
@@ -273,6 +278,8 @@ define(function (require, exports, module) {
         function adjustSibling(size) {
             if (forceLeft !== undefined) {
                 $(forceLeft, $parent).css("left", size);
+            } else if (forceRight !== undefined) {
+                $(forceRight, $parent).css("right", size);
             }
         }
 

--- a/src/view/MainViewManager.js
+++ b/src/view/MainViewManager.js
@@ -1154,7 +1154,8 @@ define(function (require, exports, module) {
         Resizer.makeResizable(firstPane.$el,
                               _orientation === HORIZONTAL ? Resizer.DIRECTION_VERTICAL : Resizer.DIRECTION_HORIZONTAL,
                               _orientation === HORIZONTAL ? Resizer.POSITION_BOTTOM : Resizer.POSITION_RIGHT,
-                              MIN_PANE_SIZE, false, false, false, true, true);
+                              MIN_PANE_SIZE, false, false, false,
+            true, undefined, true);
 
         firstPane.$el.on("panelResizeUpdate", function () {
             _updateLayout();

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -54,6 +54,13 @@ define(function (require, exports, module) {
      */
     var $editorHolder;
 
+
+    /**
+     * The "#main-toolbay": to the right side holding plugin panels and icons
+     * @type {jQueryObject}
+     */
+    var $mainToolbar;
+
     /**
      * A map from panel ID's to all reated panels
      */
@@ -97,6 +104,8 @@ define(function (require, exports, module) {
                 $elem.data("maxsize", editorAreaHeight + $elem.outerHeight());
             }
         });
+
+        $mainToolbar.data("maxsize", window.innerWidth*.75);
     }
 
 
@@ -271,10 +280,14 @@ define(function (require, exports, module) {
     AppInit.htmlReady(function () {
         $windowContent = $(".content");
         $editorHolder = $("#editor-holder");
+        $mainToolbar = $("#main-toolbar");
 
         // Sidebar is a special case: it isn't a Panel, and is not created dynamically. Need to explicitly
         // listen for resize here.
         listenToResize($("#sidebar"));
+
+        Resizer.makeResizable($mainToolbar, Resizer.DIRECTION_HORIZONTAL, Resizer.POSITION_LEFT, 30,
+            true, undefined, true, undefined, $(".content"));
     });
 
     /* Unit test only: allow passing in mock DOM notes, e.g. for use with SpecRunnerUtils.createMockEditor() */


### PR DESCRIPTION
![pluginPanel](https://user-images.githubusercontent.com/5336369/153759012-ad85d633-1883-4a0c-a483-f04a68208739.gif)

## TODOs
* fix ut failures
* Minor issues relating to status panel goes missing at times when the editor window is resized to very small.