### PR TITLE
fix: relayout ui on plugin panel resize and unit test fixes

### DIFF
--- a/src/htmlContent/main-view.html
+++ b/src/htmlContent/main-view.html
@@ -86,7 +86,7 @@
         <!-- Vertical toolbar docked to right -->
         <div id="main-toolbar" class="toolbar no-focus collapsible">
             <!-- Top-aligned buttons -->
-            <div id="plugin-panel">
+            <div id="main-plugin-panel" class="plugin-panel">
             </div>
             <div class="buttons">
                 <a id="toolbar-go-live" href="#"></a> <!-- tooltip for this is set in JS -->

--- a/src/styles/brackets_patterns_override.less
+++ b/src/styles/brackets_patterns_override.less
@@ -194,9 +194,10 @@ a:focus {
     // Ensure that it stays on top
     z-index: @z-index-brackets-main-toolbar;
 
-    #plugin-panel{
+    .plugin-panel{
         width: 100%;
         height: 100%;
+        background-color: #3C3F41;
     }
 
     .buttons,

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -285,15 +285,17 @@ define(function (require, exports, module) {
         // Sidebar is a special case: it isn't a Panel, and is not created dynamically. Need to explicitly
         // listen for resize here.
         listenToResize($("#sidebar"));
+        listenToResize($("#main-toolbar"));
 
         Resizer.makeResizable($mainToolbar, Resizer.DIRECTION_HORIZONTAL, Resizer.POSITION_LEFT, 30,
             true, undefined, true, undefined, $(".content"));
     });
 
     /* Unit test only: allow passing in mock DOM notes, e.g. for use with SpecRunnerUtils.createMockEditor() */
-    function _setMockDOM($mockWindowContent, $mockEditorHolder) {
+    function _setMockDOM($mockWindowContent, $mockEditorHolder, $mockMainToolbar) {
         $windowContent = $mockWindowContent;
         $editorHolder = $mockEditorHolder;
+        $mainToolbar = $mockMainToolbar;
     }
 
     /* Add this as a capture handler so we're guaranteed to run it before the editor does its own

--- a/test/spec/EditorRedraw-test.js
+++ b/test/spec/EditorRedraw-test.js
@@ -35,7 +35,7 @@ define(function (require, exports, module) {
             MainViewManager._edit(MainViewManager.ACTIVE_PANE, testDoc);
             testEditor = testDoc._masterEditor;
             $root = $(testEditor.getRootElement());
-            WorkspaceManager._setMockDOM($("#mock-main-view"),  $root.parent());
+            WorkspaceManager._setMockDOM($("#mock-main-view"),  $root.parent(), $("#mock-main-toolbar-view"));
         });
 
         afterEach(function () {
@@ -44,7 +44,7 @@ define(function (require, exports, module) {
             testEditor = null;
             testDoc = null;
             $root = null;
-            WorkspaceManager._setMockDOM(undefined, undefined);
+            WorkspaceManager._setMockDOM(undefined, undefined, undefined);
         });
 
         // force cases


### PR DESCRIPTION
* layout the editor on resize as content panel ui had layout problems on resizing the plugin panel.
* Fix editor relayout unit tests, 1741 pass/63 fail as before.