### PR TITLE
fix: remove collapse feature for plugin panels

### DIFF
--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -323,7 +323,7 @@ define(function (require, exports, module) {
 
         $element.data("show", function () {
             var elementOffset   = $element.offset(),
-                elementSize     = elementSizeFunction.apply($element) || elementPrefs.size,
+                elementSize     = elementSizeFunction.apply($element) || elementPrefs.size || minSize,
                 contentSize     = contentSizeFunction.apply($resizableElement) || elementPrefs.contentSize;
 
             // Resize the element before showing it again. If the panel was collapsed by dragging

--- a/src/view/WorkspaceManager.js
+++ b/src/view/WorkspaceManager.js
@@ -228,7 +228,7 @@ define(function (require, exports, module) {
 
         $mainPluginPanel[0].appendChild($panel[0]);
 
-        let pluginPanel = new PluginPanelView.Panel($panel, id, $toolbarIcon);
+        let pluginPanel = new PluginPanelView.Panel($panel, id, $toolbarIcon, minSize);
         panelIDMap[id] = pluginPanel;
 
         return pluginPanel;
@@ -308,7 +308,7 @@ define(function (require, exports, module) {
 
     PluginPanelView.on(PluginPanelView.EVENT_PLUGIN_PANEL_SHOWN, (event, panelID, minWidth)=>{
         Resizer.makeResizable($mainToolbar, Resizer.DIRECTION_HORIZONTAL, Resizer.POSITION_LEFT, minWidth,
-            true, undefined, true, undefined, $windowContent);
+            false, undefined, true, undefined, $windowContent);
         recomputeLayout(true);
         exports.trigger(EVENT_WORKSPACE_PANEL_SHOWN, panelID);
     });


### PR DESCRIPTION
* plugin panels are closed by clicking the corresponding plugin icon in the toolbar. removing double click to close workflow.

Double click to close was causing problems with layout and the fix was taking a long time. defer to later if the feature is requested as it is a non-p1 feature.