### PR TITLE
fix: cannot read newly created file in native file system

### DIFF
--- a/src/phoenix/fslib_native.js
+++ b/src/phoenix/fslib_native.js
@@ -116,7 +116,7 @@ async function _getFileContents(fileHandle, encoding, callback) {
             return;
         }
         let decodedString = _getDecodedString(buffer, encoding);
-        if(decodedString){
+        if(decodedString !== null){
             callback(null, decodedString, encoding);
         } else {
             callback(new Errors.EIO(`Encoding ${encoding} no supported`));


### PR DESCRIPTION
## Problem
In newly created files, the encoder was returning empty string `""` and javascript treats an empty string as falsey and the check was causing false positives.

This only happens in the native file system, ie folders mounted from the actual user's system into phoenix. This peobelm doesn't happen in browser filer fs.

## solution
If decoding fails, `null` string is returned. So we specifically check for null string to verify decode failure.