### PR TITLE
feat: extension interface for inter extension communication

### DIFF
--- a/src/utils/ExtensionInterface.js
+++ b/src/utils/ExtensionInterface.js
@@ -1,0 +1,79 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Modified Work Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2012 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global less */
+// jshint ignore: start
+
+/**
+ * ExtensionInterface defines utility methods for communicating between extensions safely.
+ */
+define(function (require, exports, module) {
+    const EVENT_EXTENSION_INTERFACE_REGISTERED = "extensionInterfaceRegistered";
+
+    let EventDispatcher = require("utils/EventDispatcher");
+
+    let _extensionInterfaceMap = {};
+
+    /**
+     * Registers a named extension interface. Will overwrite if an interface of the same name is already present.
+     * @param {string} extensionInterfaceName
+     * @param {Object} interfaceObject
+     */
+    function registerExtensionInterface(extensionInterfaceName, interfaceObject) {
+        _extensionInterfaceMap[extensionInterfaceName] = interfaceObject;
+        exports.trigger(EVENT_EXTENSION_INTERFACE_REGISTERED, extensionInterfaceName, interfaceObject);
+    }
+
+    /**
+     * Returns true is an interface of the given name exists.
+     * @param {string} extensionInterfaceName
+     * @return {boolean}
+     */
+    function isExistsExtensionInterface(extensionInterfaceName) {
+        return _extensionInterfaceMap[extensionInterfaceName] !== undefined;
+    }
+
+    /**
+     * Returns a promise that gets resolved only when an ExtensionInterface of the given name is registered. Use this
+     * getter to get hold of extensions interface predictably.
+     * @param extensionInterfaceName
+     * @return {Promise}
+     */
+    function awaitGetExtensionInterface(extensionInterfaceName) {
+        return new Promise((resolve, reject)=>{
+            let registrationEventHandler = function (event, registeredInterfaceName, interfaceObj) {
+                if(registeredInterfaceName === extensionInterfaceName){
+                    exports.off(EVENT_EXTENSION_INTERFACE_REGISTERED, registrationEventHandler);
+                    resolve(interfaceObj);
+                }
+            };
+            exports.on(EVENT_EXTENSION_INTERFACE_REGISTERED, registrationEventHandler);
+        });
+    }
+
+    EventDispatcher.makeEventDispatcher(exports);
+    // Public API
+    exports.registerExtensionInterface = registerExtensionInterface;
+    exports.awaitGetExtensionInterface = awaitGetExtensionInterface;
+    exports.isExistsExtensionInterface = isExistsExtensionInterface;
+    // Events
+    exports.EVENT_EXTENSION_INTERFACE_REGISTERED = EVENT_EXTENSION_INTERFACE_REGISTERED;
+});

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -41,6 +41,7 @@ define(function (require, exports, module) {
     require("spec/EditorManager-test");
     require("spec/EventDispatcher-test");
     require("spec/ExtensionInstallation-test");
+    require("spec/ExtensionInterface-test");
     require("spec/ExtensionLoader-test");
     require("spec/ExtensionManager-test");
     require("spec/ExtensionUtils-test");

--- a/test/spec/ExtensionInterface-test.js
+++ b/test/spec/ExtensionInterface-test.js
@@ -1,0 +1,64 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Modified Work Copyright (c) 2021 - present core.ai . All rights reserved.
+ * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global describe, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waitsFor, runs, waitsForDone */
+
+define(function (require, exports, module) {
+    const ExtensionInterface = require("utils/ExtensionInterface"),
+        INTERFACE_OBJ = {
+            "hello": "world"
+        };
+
+    describe("Extension Interface tests", function () {
+        it("should return a registered interface", function () {
+            const INTERFACE_1 = "int1";
+            ExtensionInterface.registerExtensionInterface(INTERFACE_1, INTERFACE_OBJ);
+            expect(ExtensionInterface.isExistsExtensionInterface(INTERFACE_1)).toEqual(true);
+        });
+
+        it("should raise event on extension registration", function () {
+            const INTERFACE_1 = "int1";
+            let notified = false, interfaceObjNotified = null;
+            ExtensionInterface.on(ExtensionInterface.EVENT_EXTENSION_INTERFACE_REGISTERED, (event, name, intrfaceObj)=>{
+                notified = name;
+                interfaceObjNotified = intrfaceObj;
+            });
+            ExtensionInterface.registerExtensionInterface(INTERFACE_1, INTERFACE_OBJ);
+            expect(ExtensionInterface.isExistsExtensionInterface(INTERFACE_1)).toEqual(true);
+            waitsFor(function () {
+                return notified === INTERFACE_1 && interfaceObjNotified === INTERFACE_OBJ;
+            }, 100, "extension interface registration notification");
+        });
+
+        it("should await and get the extension interface", function () {
+            const INTERFACE_2 = "int2";
+            let extensionInterface = null;
+            ExtensionInterface.awaitGetExtensionInterface(INTERFACE_2).then((interfaceObj)=>{
+                extensionInterface = interfaceObj;
+            });
+
+            ExtensionInterface.registerExtensionInterface(INTERFACE_2, INTERFACE_OBJ);
+            waitsFor(function () {
+                return extensionInterface === INTERFACE_OBJ;
+            }, 100, "awaiting extension interface");
+        });
+    });
+});


### PR DESCRIPTION
There should be a way for extensions to effectively communicate with each other. Currently, the command manager can be used to register custom extension commands. But it is quite limiting for use cases involving direct function calls/event triggering. 

With this change, a new ExtensionInterface is defined that can be used by extensions to register named interfaces. Extensions in brackets are loaded unpredictably/when deemed required by brackets and getting an interface can only work after the extension is loaded. Methods are provided that allow getting hold of these interfaces as and when they are registered as part of the extension life cycle.