### PR TITLE
feat: live preview panel shows up on app start

### DIFF
--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -94,7 +94,9 @@ define(function (require, exports, module) {
     }
 
     function _loadPreview() {
-        $iframe.attr('src', utils.getPreviewURL());
+        if(panel.isVisible()){
+            $iframe.attr('src', utils.getPreviewURL());
+        }
     }
 
     AppInit.appReady(function () {
@@ -102,6 +104,10 @@ define(function (require, exports, module) {
         ProjectManager.on(ProjectManager.EVENT_PROJECT_OPEN, _loadPreview);
         ProjectManager.on(ProjectManager.EVENT_PROJECT_FILE_CHANGED, _loadPreview);
         EditorManager.on("activeEditorChange", _loadPreview);
+        // We always show the live preview panel on startup
+        setTimeout(()=>{
+            _setPanelVisibility(true);
+        }, 1000);
     });
 });
 

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -58,8 +58,7 @@ define(function (require, exports, module) {
         $panel;
 
     // Other vars
-    var panel,
-        toggleCmd;
+    var panel;
 
     function _setPanelVisibility(isVisible) {
         if (isVisible) {
@@ -76,8 +75,6 @@ define(function (require, exports, module) {
     function _toggleVisibility() {
         let visible = !panel.isVisible();
         _setPanelVisibility(visible);
-
-        toggleCmd.setChecked(visible);
     }
 
     function _createExtensionPanel() {


### PR DESCRIPTION
- fix: removed unused variables
- feat: live preview panel shows up on app start
