### PR TITLE
feat: feature gate to selectively enable features in development

### DIFF
--- a/src/utils/ExtensionInterface.js
+++ b/src/utils/ExtensionInterface.js
@@ -1,8 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified Work Copyright (c) 2021 - present core.ai . All rights reserved.
- * Original work Copyright (c) 2012 - 2021 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
@@ -24,6 +23,7 @@
 
 /**
  * ExtensionInterface defines utility methods for communicating between extensions safely.
+ * See <doc link here for more details on how to use this API>
  */
 define(function (require, exports, module) {
     const EVENT_EXTENSION_INTERFACE_REGISTERED = "extensionInterfaceRegistered";
@@ -57,7 +57,7 @@ define(function (require, exports, module) {
      * @param extensionInterfaceName
      * @return {Promise}
      */
-    function awaitGetExtensionInterface(extensionInterfaceName) {
+    function waitAndGetExtensionInterface(extensionInterfaceName) {
         return new Promise((resolve, reject)=>{
             let registrationEventHandler = function (event, registeredInterfaceName, interfaceObj) {
                 if(registeredInterfaceName === extensionInterfaceName){
@@ -72,7 +72,7 @@ define(function (require, exports, module) {
     EventDispatcher.makeEventDispatcher(exports);
     // Public API
     exports.registerExtensionInterface = registerExtensionInterface;
-    exports.awaitGetExtensionInterface = awaitGetExtensionInterface;
+    exports.waitAndGetExtensionInterface = waitAndGetExtensionInterface;
     exports.isExistsExtensionInterface = isExistsExtensionInterface;
     // Events
     exports.EVENT_EXTENSION_INTERFACE_REGISTERED = EVENT_EXTENSION_INTERFACE_REGISTERED;

--- a/src/utils/FeatureGate.js
+++ b/src/utils/FeatureGate.js
@@ -1,0 +1,82 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global less */
+// jshint ignore: start
+
+/**
+ * Check if certain features are enabled or disabled. This can be used to selectively enable
+ * work in progress features during development. Dev feature!!!: Not intended for production use by users.
+ * See <doc link here for more details on how to use this API>
+ */
+define(function (require, exports, module) {
+    const FEATURE_REGISTERED = "featureGateRegistered",
+        ENABLED = 'enabled',
+        DISABLED = 'disabled';
+
+    let EventDispatcher = require("utils/EventDispatcher");
+
+    let _FeatureGateMap = {};
+
+    /**
+     * Registers a named feature with the default enabled state.
+     * @param {string} featureName
+     * @param {boolean} enabledDefault
+     */
+    function registerFeatureGate(featureName, enabledDefault) {
+        if(typeof enabledDefault !== "boolean"){
+            console.warn(`Feature gate ${featureName} ignoring invalid default value: ${enabledDefault}`);
+            return;
+        }
+        _FeatureGateMap[featureName] = enabledDefault;
+        exports.trigger(FEATURE_REGISTERED, featureName, enabledDefault);
+    }
+
+    /**
+     * Returns an array of all named registered feature gates.
+     * @return {[String]} list of registered features
+     */
+    function getAllRegisteredFeatures() {
+        return Object.keys(_FeatureGateMap);
+    }
+
+    /**
+     * Returns true is an featureGate is enabled either by default or overridden by the user using local storage.
+     * @param {string} featureName
+     * @return {boolean}
+     */
+    function isFeatureEnabled(featureName) {
+        let userOverRide = localStorage.getItem(`feature.${featureName}`);
+        if(userOverRide === ENABLED){
+            return true;
+        } else if(userOverRide === DISABLED){
+            return false;
+        }
+        return _FeatureGateMap[featureName] === true;
+    }
+
+    EventDispatcher.makeEventDispatcher(exports);
+    // Public API
+    exports.registerFeatureGate = registerFeatureGate;
+    exports.getAllRegisteredFeatures = getAllRegisteredFeatures;
+    exports.isFeatureEnabled = isFeatureEnabled;
+    // Events
+    exports.FEATURE_REGISTERED = FEATURE_REGISTERED;
+});

--- a/test/UnitTestSuite.js
+++ b/test/UnitTestSuite.js
@@ -42,6 +42,7 @@ define(function (require, exports, module) {
     require("spec/EventDispatcher-test");
     require("spec/ExtensionInstallation-test");
     require("spec/ExtensionInterface-test");
+    require("spec/FeatureGate-test");
     require("spec/ExtensionLoader-test");
     require("spec/ExtensionManager-test");
     require("spec/ExtensionUtils-test");

--- a/test/spec/ExtensionInterface-test.js
+++ b/test/spec/ExtensionInterface-test.js
@@ -1,8 +1,7 @@
 /*
  * GNU AGPL-3.0 License
  *
- * Modified Work Copyright (c) 2021 - present core.ai . All rights reserved.
- * Original work Copyright (c) 2013 - 2021 Adobe Systems Incorporated. All rights reserved.
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
@@ -51,7 +50,7 @@ define(function (require, exports, module) {
         it("should await and get the extension interface", function () {
             const INTERFACE_2 = "int2";
             let extensionInterface = null;
-            ExtensionInterface.awaitGetExtensionInterface(INTERFACE_2).then((interfaceObj)=>{
+            ExtensionInterface.waitAndGetExtensionInterface(INTERFACE_2).then((interfaceObj)=>{
                 extensionInterface = interfaceObj;
             });
 

--- a/test/spec/FeatureGate-test.js
+++ b/test/spec/FeatureGate-test.js
@@ -1,0 +1,60 @@
+/*
+ * GNU AGPL-3.0 License
+ *
+ * Copyright (c) 2021 - present core.ai . All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see https://opensource.org/licenses/AGPL-3.0.
+ *
+ */
+
+/*global describe, it, expect, beforeFirst, afterLast, beforeEach, afterEach, waitsFor, runs, waitsForDone */
+
+define(function (require, exports, module) {
+    const FeatureGate = require("utils/FeatureGate");
+
+    describe("FeatureGate tests", function () {
+        it("should return a registered feature gate", function () {
+            FeatureGate.registerFeatureGate("feature1", true);
+            expect(FeatureGate.getAllRegisteredFeatures().includes("feature1")).toEqual(true);
+        });
+
+        it("should raise event on feature registration", function () {
+            const FEATURE2 = "feature2";
+            let notified = false, featureDefaultValue = null;
+            FeatureGate.on(FeatureGate.FEATURE_REGISTERED, (event, name, defaultValue)=>{
+                notified = name;
+                featureDefaultValue = defaultValue;
+            });
+            FeatureGate.registerFeatureGate(FEATURE2, true);
+            expect(FeatureGate.getAllRegisteredFeatures().includes(FEATURE2)).toEqual(true);
+            waitsFor(function () {
+                return notified === FEATURE2 && featureDefaultValue === true;
+            }, 100, "Feature gate registration notification");
+        });
+
+        it("user should be able to override feature in localstorage", function () {
+            const FEATURENAME = "feature3",
+                STORAGE_KEY = `feature.${FEATURENAME}`;
+            localStorage.removeItem(STORAGE_KEY);
+            FeatureGate.registerFeatureGate(FEATURENAME, true);
+
+            localStorage.setItem(STORAGE_KEY, "enabled");
+            expect(FeatureGate.isFeatureEnabled(FEATURENAME)).toEqual(true);
+            localStorage.setItem(STORAGE_KEY, "disabled");
+            expect(FeatureGate.isFeatureEnabled(FEATURENAME)).toEqual(false);
+            localStorage.setItem(STORAGE_KEY, "invalidValueWillHonorDefaultValue");
+            expect(FeatureGate.isFeatureEnabled(FEATURENAME)).toEqual(true);
+        });
+    });
+});


### PR DESCRIPTION
* During development, users can enable or disable features setting `feature.<featureName>`  to `enabled` or `disabled` 
* Extensions should use the FeatureGate API to expose named feature gates.
* Minor change in API name fore ExtensionInterface