### PR TITLE
fix: boot project load recovery on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Phoenix is in early alpha.
 4. Uncompromised local development experience.
 5. Support for pluggable remote back-ends.
 6. Phoenix core will work from a static web server.
+7. No minification/compilation step or code obfuscation of release builds for code auditability and readability.
+
+AGPL/Libre license guards your right to audit and change code that handles your data.
+Phoenix usually loads up in under one second and loading it faster at the expense of making it hard
+to read and develop is a noop. We prioritize simplicity and eaze of development. 
 
 ## Status
 Phoenix is in alpha and is under active development.

--- a/src/command/KeyBindingManager.js
+++ b/src/command/KeyBindingManager.js
@@ -19,6 +19,7 @@
  *
  */
 
+/*globals path*/
 /*jslint regexp: true */
 /*unittests: KeyBindingManager */
 
@@ -47,7 +48,7 @@ define(function (require, exports, module) {
     var KeyboardPrefs       = JSON.parse(require("text!base-config/keyboard.json"));
 
     var KEYMAP_FILENAME     = "keymap.json",
-        _userKeyMapFilePath = brackets.app.getApplicationSupportDirectory() + "/" + KEYMAP_FILENAME;
+        _userKeyMapFilePath = path.normalize(brackets.app.getApplicationSupportDirectory() + "/" + KEYMAP_FILENAME);
 
     /**
      * @private
@@ -283,7 +284,7 @@ define(function (require, exports, module) {
         _customKeyMapCache = {};
         _commandMap = {};
         _globalKeydownHooks = [];
-        _userKeyMapFilePath = brackets.app.getApplicationSupportDirectory() + "/" + KEYMAP_FILENAME;
+        _userKeyMapFilePath = path.normalize(brackets.app.getApplicationSupportDirectory() + "/" + KEYMAP_FILENAME);
     }
 
     /**
@@ -1282,7 +1283,7 @@ define(function (require, exports, module) {
      */
     function _getUserKeyMapFilePath() {
         if (window.isBracketsTestWindow) {
-            return brackets.app.getApplicationSupportDirectory() + "/_test_/" + KEYMAP_FILENAME;
+            return path.normalize(brackets.app.getApplicationSupportDirectory() + "/_test_/" + KEYMAP_FILENAME);
         }
         return _userKeyMapFilePath;
     }

--- a/src/extensions/default/DebugCommands/main.js
+++ b/src/extensions/default/DebugCommands/main.js
@@ -19,6 +19,7 @@
  *
  */
 
+/*globals path*/
 /*jslint regexp: true */
 
 define(function (require, exports, module) {
@@ -53,7 +54,7 @@ define(function (require, exports, module) {
         SUPPORTED_PREFERENCE_TYPES   = ["number", "boolean", "string", "array", "object"];
 
     var recomputeDefaultPrefs        = true,
-        defaultPreferencesFullPath   = brackets.app.getApplicationSupportDirectory() + "/" + DEFAULT_PREFERENCES_FILENAME;
+        defaultPreferencesFullPath   = path.normalize(brackets.app.getApplicationSupportDirectory() + "/" + DEFAULT_PREFERENCES_FILENAME);
 
     /**
      * Brackets Application Menu Constant

--- a/src/filesystem/FileIndex.js
+++ b/src/filesystem/FileIndex.js
@@ -34,6 +34,7 @@ define(function (require, exports, module) {
      */
     function FileIndex() {
         this._index = {};
+        this._doNotRemoveItems = {};
     }
 
     /**
@@ -43,11 +44,21 @@ define(function (require, exports, module) {
      */
     FileIndex.prototype._index = null;
 
+    FileIndex.prototype._doNotRemoveItems = null;
+
     /**
      * Clear the file index cache.
      */
     FileIndex.prototype.clear = function () {
         this._index = {};
+        this._doNotRemoveItems = {};
+    };
+
+    /**
+     * Will prevent the file from being removed from index. However, it is reset when index is cleared.
+     */
+    FileIndex.prototype.doNotRemoveFromIndex = function (filePath) {
+        this._doNotRemoveItems[filePath] = true;
     };
 
     /**
@@ -80,6 +91,9 @@ define(function (require, exports, module) {
     FileIndex.prototype.removeEntry = function (entry) {
         var path = entry.fullPath,
             property;
+        if(this._doNotRemoveItems[path]){
+            return;
+        }
 
         function replaceMember(property) {
             var member = entry[property];

--- a/src/filesystem/FileSystem.js
+++ b/src/filesystem/FileSystem.js
@@ -448,6 +448,13 @@ define(function (require, exports, module) {
     };
 
     /**
+     * Will never remove the given file from index. Useful if you want to always hold cache the file.
+     */
+    FileSystem.prototype.alwaysIndex = function (filePath) {
+        this._index.doNotRemoveFromIndex(filePath);
+    };
+
+    /**
      * Returns true if the given path should be automatically added to the index & watch list when one of its ancestors
      * is a watch-root. (Files are added automatically when the watch-root is first established, or later when a new
      * directory is created and its children enumerated).
@@ -1064,6 +1071,7 @@ define(function (require, exports, module) {
     exports.watch = _wrap(FileSystem.prototype.watch);
     exports.unwatch = _wrap(FileSystem.prototype.unwatch);
     exports.clearAllCaches = _wrap(FileSystem.prototype.clearAllCaches);
+    exports.alwaysIndex = _wrap(FileSystem.prototype.alwaysIndex);
 
     // Static public utility methods
     exports.isAbsolutePath = FileSystem.isAbsolutePath;

--- a/src/preferences/PreferencesBase.js
+++ b/src/preferences/PreferencesBase.js
@@ -1770,34 +1770,34 @@ define(function (require, exports, module) {
          * @return {Promise} Resolved when the preferences are done saving.
          */
         save: function () {
-            if (this._saveInProgress) {
-                if (!this._nextSaveDeferred) {
-                    this._nextSaveDeferred = new $.Deferred();
+            let that = this;
+            if (that._saveInProgress) {
+                if (!that._nextSaveDeferred) {
+                    that._nextSaveDeferred = new $.Deferred();
                 }
-                return this._nextSaveDeferred.promise();
+                return that._nextSaveDeferred.promise();
             }
 
-            var deferred = this._nextSaveDeferred || (new $.Deferred());
+            var deferred = that._nextSaveDeferred || (new $.Deferred());
             this._saveInProgress = true;
             this._nextSaveDeferred = null;
 
-            Async.doInParallel(_.values(this._scopes), function (scope) {
+            Async.doInParallel(_.values(that._scopes), function (scope) {
                 if (scope) {
                     return scope.save();
                 }
                 return (new $.Deferred()).resolve().promise();
 
-            }.bind(this))
-                .then(function () {
-                    this._saveInProgress = false;
-                    if (this._nextSaveDeferred) {
-                        this.save();
-                    }
-                    deferred.resolve();
-                }.bind(this))
-                .fail(function (err) {
-                    deferred.reject(err);
-                });
+            }).then(function () {
+                that._saveInProgress = false;
+                if (that._nextSaveDeferred) {
+                    that.save();
+                }
+                deferred.resolve();
+            }).fail(function (err) {
+                that._saveInProgress = false;
+                deferred.reject(err);
+            });
 
             return deferred.promise();
         },

--- a/src/preferences/PreferencesImpl.js
+++ b/src/preferences/PreferencesImpl.js
@@ -19,6 +19,8 @@
  *
  */
 
+/*globals path*/
+
 /**
  * Generates the fully configured preferences systems used throughout Brackets. This is intended
  * to be essentially private implementation that can be overridden for tests.
@@ -28,13 +30,14 @@ define(function (require, exports, module) {
 
     var PreferencesBase = require("./PreferencesBase"),
         Async           = require("utils/Async"),
+        FileSystem      = require("filesystem/FileSystem"),
 
         // The SETTINGS_FILENAME is used with a preceding "." within user projects
         SETTINGS_FILENAME = "brackets.json",
         STATE_FILENAME    = "state.json",
 
         // User-level preferences
-        userPrefFile = brackets.app.getApplicationSupportDirectory() + "/" + SETTINGS_FILENAME;
+        userPrefFile = path.normalize(brackets.app.getApplicationSupportDirectory() + "/" + SETTINGS_FILENAME);
 
     /**
      * A deferred object which is used to indicate PreferenceManager readiness during the start-up.
@@ -111,7 +114,8 @@ define(function (require, exports, module) {
     // "State" is stored like preferences but it is not generally intended to be user-editable.
     // It's for more internal, implicit things like window size, working set, etc.
     var stateManager = new PreferencesBase.PreferencesSystem();
-    var userStateFile = brackets.app.getApplicationSupportDirectory() + "/" + STATE_FILENAME;
+    var userStateFile = path.normalize(brackets.app.getApplicationSupportDirectory() + "/" + STATE_FILENAME);
+    FileSystem.alwaysIndex(userStateFile);
     var smUserScope = new PreferencesBase.Scope(new PreferencesBase.FileStorage(userStateFile, true, true));
     var stateProjectLayer = new PreferencesBase.ProjectLayer();
     smUserScope.addLayer(stateProjectLayer);
@@ -121,7 +125,7 @@ define(function (require, exports, module) {
     // Listen for times where we might be unwatching a root that contains one of the user-level prefs files,
     // and force a re-read of the file in order to ensure we can write to it later (see #7300).
     function _reloadUserPrefs(rootDir) {
-        var prefsDir = brackets.app.getApplicationSupportDirectory() + "/";
+        var prefsDir = path.normalize(brackets.app.getApplicationSupportDirectory() + "/");
         if (prefsDir.indexOf(rootDir.fullPath) === 0) {
             manager.fileChanged(userPrefFile);
             stateManager.fileChanged(userStateFile);

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -717,7 +717,7 @@ define(function (require, exports, module) {
      */
     function addWelcomeProjectPath(path) {
         var welcomeProjects = ProjectModel._addWelcomeProjectPath(path,
-                                                                 PreferencesManager.getViewState("welcomeProjects"));
+            PreferencesManager.getViewState("welcomeProjects"));
         PreferencesManager.setViewState("welcomeProjects", welcomeProjects);
     }
 
@@ -792,11 +792,29 @@ define(function (require, exports, module) {
     }
 
     /**
+     * @deprecated use getStartupProjectPath instead. Can be removed anytime after 2-Apr-2023.
      * Initial project path is stored in prefs, which defaults to the welcome project on
      * first launch.
      */
     function getInitialProjectPath() {
         return updateWelcomeProjectPath(PreferencesManager.getViewState("projectPath"));
+    }
+
+    /**
+     * Initial project path is stored in prefs, which defaults to the welcome project on
+     * first launch.
+     */
+    async function getStartupProjectPath() {
+        return new Promise((resolve)=>{
+            let startupProjectPath = updateWelcomeProjectPath(PreferencesManager.getViewState("projectPath"));
+            FileSystem.getDirectoryForPath(startupProjectPath).exists((err, exists)=>{
+                if(exists){
+                    resolve(startupProjectPath);
+                } else {
+                    resolve(_getWelcomeProjectPath());
+                }
+            });
+        });
     }
 
     /**
@@ -1501,6 +1519,7 @@ define(function (require, exports, module) {
     exports.getSelectedItem               = getSelectedItem;
     exports.getContext                    = getContext;
     exports.getInitialProjectPath         = getInitialProjectPath;
+    exports.getStartupProjectPath         = getStartupProjectPath;
     exports.isWelcomeProjectPath          = isWelcomeProjectPath;
     exports.updateWelcomeProjectPath      = updateWelcomeProjectPath;
     exports.createNewItem                 = createNewItem;


### PR DESCRIPTION
* If the startup project could not be read, we will launch the default project. A startup
project load can fail if it is a native mounted folder which doesnt have permissions.
* Fixes to always index /app/state.json preferences file. Earlier, the index was getting reset
on project switch and save of preferences was failing as the rpeferences saver saw two files,
one with an index entry and one without.
