### PR TITLE
feat: remember last previewed file when switching between project files

### DIFF
--- a/src/extensions/default/DefaultExtensions.json
+++ b/src/extensions/default/DefaultExtensions.json
@@ -34,6 +34,5 @@
   "HealthData",
   "Phoenix-extension-store",
   "Phoenix-live-preview",
-  "Phoenix-Markdown",
-  "Phoenix-prettier"
+  "Phoenix-Markdown"
 ]

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -121,7 +121,11 @@ define(function (require, exports, module) {
             };
             // panel-live-preview-title
             let previewDetails = await utils.getPreviewDetails();
-            let newSrc = encodeURI(previewDetails.URL);
+            let newSrc = currentSrc;
+            if (previewDetails.URL) {
+                newSrc = encodeURI(previewDetails.URL);
+                _setTitle(previewDetails.filePath);
+            }
             $iframe[0].onload = function () {
                 if(currentSrc === newSrc){
                     $iframe[0].contentWindow.scrollTo(scrollX, scrollY);
@@ -133,8 +137,7 @@ define(function (require, exports, module) {
                 }
             };
             if(currentSrc !== newSrc || force){
-                $iframe.attr('src', previewDetails.URL);
-                _setTitle(previewDetails.filePath);
+                $iframe.attr('src', newSrc);
             }
         }
     }

--- a/src/extensions/default/Phoenix-live-preview/utils.js
+++ b/src/extensions/default/Phoenix-live-preview/utils.js
@@ -77,6 +77,11 @@ define(function (require, exports, module) {
         });
     }
 
+    /**
+     * Finds out a {URL,filePath} to live preview from the project. Will return and empty object if the current
+     * file is not previewable.
+     * @return {Promise<*>}
+     */
     async function getPreviewDetails() {
         return new Promise(async (resolve)=>{
             const projectRoot = ProjectManager.getProjectRoot().fullPath;
@@ -91,6 +96,8 @@ define(function (require, exports, module) {
                         URL: `${projectRootUrl}${relativePath}`,
                         filePath: relativePath
                     });
+                } else {
+                    resolve({}); // not a previewable file
                 }
             }
             resolve(await _getDefaultPreviewDetails());


### PR DESCRIPTION
- feat: remember last previewed file when switching between project files
- chore: temporarily remove prettier WIP extension from loading