### PR TITLE
chore: always load from url like x/ instead of x/index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -59,6 +59,12 @@
     <!-- endbuild -->
     <script>
         function _loadPhoenixAfterSplashScreen() {
+            if(location.href.endsWith("index.html")){
+                console.log("Redirecting to root dir for phoenix paths to work properly.");
+                let currentUrl = location.href;
+                let lastIndex = currentUrl.lastIndexOf("index.html");
+                location.href = currentUrl.substring(0, lastIndex);
+            }
             var loadJS = function(url, implementationCode, location, dataMainValue){
                 //url is URL of external file, implementationCode is the code
                 //to be called from the file, location is the location to


### PR DESCRIPTION
If we see that the url ends with a/b/index.html, we will redirect to a/b/
