### PR TITLE
chore: remove show in os file, no browser support

### DIFF
--- a/src/command/DefaultMenus.js
+++ b/src/command/DefaultMenus.js
@@ -55,7 +55,7 @@ define(function (require, exports, module) {
                 if (err) {
                     return err;
                 }
-                _setContextMenuItemsVisible(isPresent, [Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS]);
+                _setContextMenuItemsVisible(isPresent, [Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE]);
             });
         }
     }
@@ -228,7 +228,6 @@ define(function (require, exports, module) {
         workingset_cmenu.addMenuItem(Commands.FILE_SAVE_AS);
         workingset_cmenu.addMenuItem(Commands.FILE_RENAME);
         workingset_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_FILE_TREE);
-        workingset_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
         workingset_cmenu.addMenuDivider();
         workingset_cmenu.addMenuItem(Commands.CMD_FIND_IN_SUBTREE);
         workingset_cmenu.addMenuItem(Commands.CMD_REPLACE_IN_SUBTREE);
@@ -251,7 +250,6 @@ define(function (require, exports, module) {
         project_cmenu.addMenuItem(Commands.FILE_NEW_FOLDER);
         project_cmenu.addMenuItem(Commands.FILE_RENAME);
         project_cmenu.addMenuItem(Commands.FILE_DELETE);
-        project_cmenu.addMenuItem(Commands.NAVIGATE_SHOW_IN_OS);
         project_cmenu.addMenuDivider();
         project_cmenu.addMenuItem(Commands.CMD_FIND_IN_SUBTREE);
         project_cmenu.addMenuItem(Commands.CMD_REPLACE_IN_SUBTREE);

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1618,18 +1618,6 @@ define(function (require, exports, module) {
             });
     }
 
-    /** Show the selected sidebar (tree or workingset) item in Finder/Explorer */
-    function handleShowInOS() {
-        var entry = ProjectManager.getSelectedItem();
-        if (entry) {
-            brackets.app.showOSFolder(entry.fullPath, function (err) {
-                if (err) {
-                    console.error("Error showing '" + entry.fullPath + "' in OS folder:", err);
-                }
-            });
-        }
-    }
-
     /**
     * Does a full reload of the browser window
     * @param {string} href The url to reload into the window
@@ -1769,13 +1757,9 @@ define(function (require, exports, module) {
     exports._parseDecoratedPath = _parseDecoratedPath;
 
     // Set some command strings
-    var quitString  = Strings.CMD_QUIT,
-        showInOS    = Strings.CMD_SHOW_IN_OS;
+    var quitString  = Strings.CMD_QUIT;
     if (brackets.platform === "win") {
         quitString  = Strings.CMD_EXIT;
-        showInOS    = Strings.CMD_SHOW_IN_EXPLORER;
-    } else if (brackets.platform === "mac") {
-        showInOS    = Strings.CMD_SHOW_IN_FINDER;
     }
 
     // Define public API
@@ -1814,7 +1798,6 @@ define(function (require, exports, module) {
     CommandManager.register(Strings.CMD_PREV_DOC_LIST_ORDER,         Commands.NAVIGATE_PREV_DOC_LIST_ORDER,   handleGoPrevDocListOrder);
 
     // Special Commands
-    CommandManager.register(showInOS,                                Commands.NAVIGATE_SHOW_IN_OS,            handleShowInOS);
     CommandManager.register(quitString,                              Commands.FILE_QUIT,                      handleFileQuit);
     CommandManager.register(Strings.CMD_SHOW_IN_TREE,                Commands.NAVIGATE_SHOW_IN_FILE_TREE,     handleShowInTree);
 


### PR DESCRIPTION
* remove show in os from context menu.
* fs access apis does not support opening file in explorer and may not be likely to in the near future. We need to do this maybe as part of phoenix local daemons or somthing.

![image](https://user-images.githubusercontent.com/5336369/161475709-082d47dd-7501-4e5f-b4b5-a3960535e20a.png)
