### PR TITLE
chore: dedupe files to sync before publish and live preview usability improvements

### DIFF
--- a/src/assets/phoenix-splash/index.html
+++ b/src/assets/phoenix-splash/index.html
@@ -10,7 +10,7 @@
         <div id="mainDiv">
             <img id="logo"  src="images/phoenix-logo.svg"/>
             <div id="MainText">
-                <h1>phoenix</h1>
+                <h1>Phoenix</h1>
                 <span >Modern, Open-source, cloud IDE <br></span><br>
                 <button id="load-status-display-btn" class="primary-button">Loading Editor...</button>
             </div>

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -84,6 +84,9 @@ define(function (require, exports, module) {
     function _toggleVisibility() {
         let visible = !panel.isVisible();
         _setPanelVisibility(visible);
+        if(visible){
+            _loadPreview(true);
+        }
     }
 
     function _togglePinUrl() {
@@ -186,6 +189,14 @@ define(function (require, exports, module) {
         if(urlPinned){
             _togglePinUrl();
         }
+        if(!panel.isVisible()){
+            return;
+        }
+        $iframe[0].src = utils.getNoPreviewURL();
+        if(tab && !tab.closed){
+            tab.location = utils.getNoPreviewURL();
+        }
+        _loadPreview(true);
     }
 
     AppInit.appReady(function () {

--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -146,7 +146,7 @@ define(function (require, exports, module) {
         if(panel.isVisible() || (tab && !tab.closed)){
             let scrollX = $iframe[0].contentWindow.scrollX;
             let scrollY = $iframe[0].contentWindow.scrollY;
-            let currentSrc = $iframe[0].src;
+            let currentSrc = $iframe[0].src || utils.getNoPreviewURL();
             savedScrollPositions[currentSrc] = {
                 scrollX: scrollX,
                 scrollY: scrollY
@@ -189,12 +189,12 @@ define(function (require, exports, module) {
         if(urlPinned){
             _togglePinUrl();
         }
-        if(!panel.isVisible()){
-            return;
-        }
         $iframe[0].src = utils.getNoPreviewURL();
         if(tab && !tab.closed){
             tab.location = utils.getNoPreviewURL();
+        }
+        if(!panel.isVisible()){
+            return;
         }
         _loadPreview(true);
     }

--- a/src/extensions/default/Phoenix-live-preview/utils.js
+++ b/src/extensions/default/Phoenix-live-preview/utils.js
@@ -53,7 +53,7 @@ define(function (require, exports, module) {
         return false;
     }
 
-    function _getNoPreviewURL(){
+    function getNoPreviewURL(){
         return `${window.location.href}assets/phoenix-splash/no-preview.html`;
     }
 
@@ -73,7 +73,7 @@ define(function (require, exports, module) {
                     return;
                 }
             }
-            resolve({URL: _getNoPreviewURL()});
+            resolve({URL: getNoPreviewURL()});
         });
     }
 
@@ -105,6 +105,7 @@ define(function (require, exports, module) {
     }
 
     exports.getPreviewDetails = getPreviewDetails;
+    exports.getNoPreviewURL = getNoPreviewURL;
 });
 
 

--- a/src/extensions/default/Phoenix/serverSync.js
+++ b/src/extensions/default/Phoenix/serverSync.js
@@ -61,6 +61,7 @@ define(function (require, exports, module) {
     }
 
     function _uploadFile(filePath, blob, resolve, reject) {
+        console.log('Uploading file for preview: ', filePath);
         let uploadFormData = new FormData();
         let projectRoot = path.dirname(syncRoot);
         let relativePath = path.relative(projectRoot, filePath);
@@ -85,6 +86,11 @@ define(function (require, exports, module) {
 
     function _readAndUploadFile(file) {
         return new Promise((resolve, reject)=>{
+            if(file.fullPath === '/fs/app/state.json'){
+                // somehow we get these changes as project file changes too. don't sync state file
+                resolve();
+                return;
+            }
             file.read({encoding: window.fs.BYTE_ARRAY_ENCODING}, function (err, content, encoding, stat) {
                 if (err){
                     reject(err);
@@ -283,7 +289,9 @@ define(function (require, exports, module) {
             if(projectSyncCompleted){
                 previewInProgress = true;
                 _setSyncInProgress();
-                _uploadFiles(allChangedFiles, ()=>{
+                let uniqueFilesToUpload = [...new Set(allChangedFiles)];
+                allChangedFiles = [];
+                _uploadFiles(uniqueFilesToUpload, ()=>{
                     _setSyncComplete();
                     _loadPreview();
                 });

--- a/src/extensions/default/RemoteFileAdapter/main.js
+++ b/src/extensions/default/RemoteFileAdapter/main.js
@@ -54,7 +54,7 @@ define(function (require, exports, module) {
      */
     function _setMenuItemsVisible() {
         var file = MainViewManager.getCurrentlyViewedFile(MainViewManager.ACTIVE_PANE),
-            cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS],
+            cMenuItems = [Commands.FILE_SAVE, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE],
             // Enable menu options when no file is present in active pane
             enable = !file || (file.constructor.name !== "RemoteFile");
 

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -311,7 +311,7 @@ define(function (require, exports, module) {
                     cmenu.open({pageX: 0, pageY: 0});
 
                     // checks that all the relevant items are disabled
-                    var notVisible = [Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS];
+                    var notVisible = [Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE];
                     notVisible.forEach(function (item) { expect(CommandManager.get(item).getEnabled()).toBe(false); });
 
                     //close menu and new file
@@ -344,7 +344,7 @@ define(function (require, exports, module) {
                     cmenu.open({pageX: 0, pageY: 0});
 
                     // checks that all the items are enabled
-                    var visible = [Commands.FILE_SAVE, Commands.FILE_SAVE_AS, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.NAVIGATE_SHOW_IN_OS, Commands.CMD_FIND_IN_SUBTREE, Commands.CMD_REPLACE_IN_SUBTREE, Commands.FILE_CLOSE];
+                    var visible = [Commands.FILE_SAVE, Commands.FILE_SAVE_AS, Commands.FILE_RENAME, Commands.NAVIGATE_SHOW_IN_FILE_TREE, Commands.CMD_FIND_IN_SUBTREE, Commands.CMD_REPLACE_IN_SUBTREE, Commands.FILE_CLOSE];
                     visible.forEach(function (item) { expect(CommandManager.get(item).getEnabled()).toBe(true); });
                 });
             });


### PR DESCRIPTION
* Force reload live preview on project switch if live preview panel is shown.
* live preview was loading phoenix URL itself if there was nothing to preview in a project and we tried to click on live preview toolbar icon.