### PR TITLE
fix: on fresh install live preview panel had width of 50px

### DIFF
--- a/src/extensions/default/Phoenix-live-preview/main.js
+++ b/src/extensions/default/Phoenix-live-preview/main.js
@@ -125,6 +125,7 @@ define(function (require, exports, module) {
             clickToPinUnpin: Strings.LIVE_DEV_CLICK_TO_PIN_UNPIN
         };
         const PANEL_MIN_SIZE = 50;
+        const INITIAL_PANEL_SIZE = screen.width/3;
         $icon = $("#toolbar-go-live");
         $icon.click(_toggleVisibility);
         $panel = $(Mustache.render(panelHTML, templateVars));
@@ -138,7 +139,8 @@ define(function (require, exports, module) {
         let previewDetails = await utils.getPreviewDetails();
         $iframe.attr('src', previewDetails.URL);
 
-        panel = WorkspaceManager.createPluginPanel("live-preview-panel", $panel, PANEL_MIN_SIZE, $icon);
+        panel = WorkspaceManager.createPluginPanel("live-preview-panel", $panel,
+            PANEL_MIN_SIZE, $icon, INITIAL_PANEL_SIZE);
 
         WorkspaceManager.recomputeLayout(false);
         _setTitle(previewDetails.filePath);

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -201,10 +201,12 @@ define(function (require, exports, module) {
      *                          to element itself. Attach the resizer to the parent *ONLY* if element has the
      *                          same offset as parent otherwise the resizer will be incorrectly positioned.
      *                          FOR INTERNAL USE ONLY
+     * @param {?number=} initialSize  Optional Initial size of panel in px. If not given, panel will use minsize
+     *      or current size.
      */
     function makeResizable(element, direction, position, minSize, collapsible,
                            forceLeft, createdByWorkspaceManager, usePercentages,
-                           forceRight, _attachToParent) {
+                           forceRight, _attachToParent, initialSize) {
         var $resizer            = $('<div class="' + direction + '-resizer"></div>'),
             $element            = $(element),
             $parent             = $element.parent(),
@@ -325,6 +327,9 @@ define(function (require, exports, module) {
             var elementOffset   = $element.offset(),
                 elementSize     = elementSizeFunction.apply($element) || elementPrefs.size,
                 contentSize     = contentSizeFunction.apply($resizableElement) || elementPrefs.contentSize;
+            if(initialSize){
+                elementSize = elementPrefs.size || initialSize;
+            }
             if(elementSize<minSize){
                 elementSize = minSize;
             }

--- a/src/view/PluginPanelView.js
+++ b/src/view/PluginPanelView.js
@@ -37,13 +37,16 @@ define(function (require, exports, module) {
      * @param {!jQueryObject} $toolbarIcon An icon that should be present in main-toolbar to associate this panel to.
      *      The panel will be shown only if the icon is visible on the toolbar and the user clicks on the icon.
      * @param {number=} minWidth  Minimum width of panel in px.
+     * @param {?number=} initialSize  Optional Initial size of panel in px. If not given, panel will use minsize
+     *      or current size.
      */
-    function Panel($panel, id, $toolbarIcon, minWidth) {
+    function Panel($panel, id, $toolbarIcon, minWidth, initialSize) {
         this.$panel = $panel;
         this.panelID = id;
         this.$toolbarIcon = $toolbarIcon;
         this.minWidth = minWidth;
         this.$mainPluginPanel = $("#main-plugin-panel");
+        this.initialSize = initialSize;
     }
 
     /**


### PR DESCRIPTION
This happened as the live preview panel was resizing to min size when there was no values to choose from(Eg. saved panel size from last boot).

Added an initial size hint to the panel constructor to fall back to instead of min size in case of first time panel creation.